### PR TITLE
add default value for os.environ.get

### DIFF
--- a/python/fate_test/scripts/benchmark_cli.py
+++ b/python/fate_test/scripts/benchmark_cli.py
@@ -116,7 +116,7 @@ def _run_benchmark_pairs(config: Config, suite: BenchmarkSuite, tol: float, name
     # pipeline demo goes here
     pair_n = len(suite.pairs)
     fate_base = config.fate_base
-    PYTHONPATH = os.environ.get('PYTHONPATH') + ":" + os.path.join(fate_base, "python")
+    PYTHONPATH = os.environ.get('PYTHONPATH', default="") + ":" + os.path.join(fate_base, "python")
     os.environ['PYTHONPATH'] = PYTHONPATH
     for i, pair in enumerate(suite.pairs):
         echo.echo(f"Running [{i + 1}/{pair_n}] group: {pair.pair_name}")

--- a/python/fate_test/scripts/performance_cli.py
+++ b/python/fate_test/scripts/performance_cli.py
@@ -166,7 +166,7 @@ def _run_performance_jobs(config: Config, suite: PerformanceSuite, namespace: st
     # pipeline demo goes here
     job_n = len(suite.pipeline_jobs)
     fate_base = config.fate_base
-    PYTHONPATH = os.environ.get('PYTHONPATH') + ":" + os.path.join(fate_base, "python")
+    PYTHONPATH = os.environ.get('PYTHONPATH', default="") + ":" + os.path.join(fate_base, "python")
     os.environ['PYTHONPATH'] = PYTHONPATH
     job_time_history = {}
     for j, job in enumerate(suite.pipeline_jobs):


### PR DESCRIPTION
I build the fate environment using `python setup.py install`, so I don't have `PYTHONPATH`.
When execute `fate_test benchmark-quality -i benchmark_quality/hetero_nn/`, the test cannot start.
So I add the default value when the program try to get the environment variable `PYTHONPATH`
`os.environ.get('PYTHONPATH', default="")`